### PR TITLE
Allow fallback to IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,16 @@ Simple set of [middleman](http://middlemanapp.com/) rake tasks to build and depl
 ### Step 2: Require this gem in the Rakefile
 
     require 'middleman-aws'
-    
-    # Even though already required by the middleman-aws gem, it appears middleman does not 
-    #   pick up transitive dependency extensions early enough  to avoid the 
-    #   "== Unknown Extension:" error.  Add these to your main project 
+
+    # Even though already required by the middleman-aws gem, it appears middleman does not
+    #   pick up transitive dependency extensions early enough  to avoid the
+    #   "== Unknown Extension:" error.  Add these to your main project
     #   (I wish this was unnecessary but don't know how to work around it)
-    gem 'middleman-s3_sync'     
+    gem 'middleman-s3_sync'
     gem 'middleman-cloudfront'
 
 
-### Step 3: Add your aws credentials
-e.g. `~/.aws/acme.yml`
-
-This should contain the access and secret keys generated from the selected IAM user.  This is the only file that will need to reside 
-outside the repository.  `acme` is equivalent to the directory name for your project.  
-Don't worry, validation will make sure you have the path right.
-
-    access_key_id: XXXXXX
-    secret_access_key: XXXXXX
-
-### Step 4: Add the necessary s3_sync and Cloudfront sections to your config
+### Step 3: Add the necessary s3_sync and Cloudfront sections to your config
 This is a sample of how a common config is setup with variables extracted:
 
     # Configuration variables specific to each project
@@ -43,7 +33,7 @@ This is a sample of how a common config is setup with variables extracted:
     #------------------------------------------------------------------------
     AWS_ACCESS_KEY                  = ENV['AWS_ACCESS_KEY']
     AWS_SECRET                      = ENV['AWS_SECRET']
-    
+
     # https://github.com/fredjean/middleman-s3_sync
     activate :s3_sync do |s3_sync|
       s3_sync.bucket                     = AWS_BUCKET # The name of the S3 bucket you are targeting. This is globally unique.
@@ -51,7 +41,7 @@ This is a sample of how a common config is setup with variables extracted:
       s3_sync.aws_secret_access_key      = AWS_SECRET
       s3_sync.delete                     = false # We delete stray files by default.
     end
-    
+
     # https://github.com/andrusha/middleman-cloudfront
     activate :cloudfront do |cf|
       cf.access_key_id                    = AWS_ACCESS_KEY
@@ -61,7 +51,7 @@ This is a sample of how a common config is setup with variables extracted:
     end
 
 # Usage
-Run the desired rake task.  It's as simple as `rake mm:publish` in one step, or you can choose to do things one step at a time.  
+Run the desired rake task.  It's as simple as `rake mm:publish` in one step, or you can choose to do things one step at a time.
 See the available rake tasks below or run `rake -T`
 
 # Available Rake Tasks
@@ -73,8 +63,8 @@ See the available rake tasks below or run `rake -T`
     rake mm:publish      # One step clobber, build, deploy
     rake mm:show_config  # Show config
 
-# Real World Sample 
-If you are just getting started with middleman and want to get a quick jumpstart on your `Gemfile` and `congfig.rb`, 
+# Real World Sample
+If you are just getting started with middleman and want to get a quick jumpstart on your `Gemfile` and `congfig.rb`,
 check out the source in the `samples` directory for a set of commonly used configurations/gems/extensions.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,34 +21,49 @@ Simple set of [middleman](http://middlemanapp.com/) rake tasks to build and depl
     gem 'middleman-cloudfront'
 
 
-### Step 3: Add the necessary s3_sync and Cloudfront sections to your config
+### Step 3: Add your aws credentials
+e.g. `~/.aws/acme.yml`
+
+This should contain the access and secret keys generated from the selected IAM user.  This is the only file that will need to reside
+outside the repository.  `acme` is equivalent to the directory name for your project.
+Don't worry, validation will make sure you have the path right.
+
+```ruby
+access_key_id: XXXXXX
+secret_access_key: XXXXXX
+```
+
+
+### Step 4: Add the necessary s3_sync and Cloudfront sections to your config
 This is a sample of how a common config is setup with variables extracted:
 
-    # Configuration variables specific to each project
-    #------------------------------------------------------------------------
-    AWS_BUCKET                      = 'acme.alienfast.com'
-    AWS_CLOUDFRONT_DISTRIBUTION_ID  = 'xxxxxx'
+```ruby
+# Configuration variables specific to each project
+#------------------------------------------------------------------------
+AWS_BUCKET                      = 'acme.alienfast.com'
+AWS_CLOUDFRONT_DISTRIBUTION_ID  = 'xxxxxx'
 
-    # Variables: Sent in on CLI by rake task via ENV
-    #------------------------------------------------------------------------
-    AWS_ACCESS_KEY                  = ENV['AWS_ACCESS_KEY']
-    AWS_SECRET                      = ENV['AWS_SECRET']
+# Variables: Sent in on CLI by rake task via ENV
+#------------------------------------------------------------------------
+AWS_ACCESS_KEY                  = ENV['AWS_ACCESS_KEY']
+AWS_SECRET                      = ENV['AWS_SECRET']
 
-    # https://github.com/fredjean/middleman-s3_sync
-    activate :s3_sync do |s3_sync|
-      s3_sync.bucket                     = AWS_BUCKET # The name of the S3 bucket you are targeting. This is globally unique.
-      s3_sync.aws_access_key_id          = AWS_ACCESS_KEY
-      s3_sync.aws_secret_access_key      = AWS_SECRET
-      s3_sync.delete                     = false # We delete stray files by default.
-    end
+# https://github.com/fredjean/middleman-s3_sync
+activate :s3_sync do |s3_sync|
+  s3_sync.bucket                     = AWS_BUCKET # The name of the S3 bucket you are targeting. This is globally unique.
+  s3_sync.aws_access_key_id          = AWS_ACCESS_KEY
+  s3_sync.aws_secret_access_key      = AWS_SECRET
+  s3_sync.delete                     = false # We delete stray files by default.
+end
 
-    # https://github.com/andrusha/middleman-cloudfront
-    activate :cloudfront do |cf|
-      cf.access_key_id                    = AWS_ACCESS_KEY
-      cf.secret_access_key                = AWS_SECRET
-      cf.distribution_id                  = AWS_CLOUDFRONT_DISTRIBUTION_ID
-      # cf.filter = /\.html$/i
-    end
+# https://github.com/andrusha/middleman-cloudfront
+activate :cloudfront do |cf|
+  cf.access_key_id                    = AWS_ACCESS_KEY
+  cf.secret_access_key                = AWS_SECRET
+  cf.distribution_id                  = AWS_CLOUDFRONT_DISTRIBUTION_ID
+  # cf.filter = /\.html$/i
+end
+```
 
 # Usage
 Run the desired rake task.  It's as simple as `rake mm:publish` in one step, or you can choose to do things one step at a time.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ access_key_id: XXXXXX
 secret_access_key: XXXXXX
 ```
 
+If you don't create config file, then environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` will be used. If there are no such variables, then request to AWS will fail (unless middleman-aws is used on EC2 instance with correct IAM role, then AWS will take care of authorising requests).
+
 ### Step 4: Add the necessary s3_sync and Cloudfront sections to your config
 This is a sample of how a common config is setup with variables extracted:
 

--- a/lib/middleman-aws/tasks/middleman-aws.rake
+++ b/lib/middleman-aws/tasks/middleman-aws.rake
@@ -24,14 +24,10 @@ namespace :mm do
 
     puts '## Deploy starting...'
     cd 'build' do
-      # system 'git add .'
       system 'git add -u'
       message = "Site updated at #{Time.now}"
       puts "## Commiting: #{message}"
       system "git commit -m \"#{message}\""
-      # puts "## Pushing generated website"
-      # system "git push origin master"
-      # puts "## Github Pages deploy complete"
     end
 
     aws_env = "AWS_ACCESS_KEY=#{credentials[:access_key_id]} AWS_SECRET=#{credentials[:secret_access_key]}"

--- a/lib/middleman-aws/tasks/middleman-aws.rake
+++ b/lib/middleman-aws/tasks/middleman-aws.rake
@@ -34,8 +34,7 @@ namespace :mm do
       # puts "## Github Pages deploy complete"
     end
 
-    credentials!
-    aws_env = "AWS_ACCESS_KEY=#{credentials['access_key_id']} AWS_SECRET=#{credentials['secret_access_key']}"
+    aws_env = "AWS_ACCESS_KEY=#{credentials[:access_key_id]} AWS_SECRET=#{credentials[:secret_access_key]}"
     puts '## Syncing to S3...'
     system "#{aws_env} bundle exec middleman s3_sync"
     puts '## Invalidating cloudfront...'
@@ -56,22 +55,22 @@ namespace :mm do
   desc 'Show config'
   task :show_config do |t, args|
 
-    credentials!
-
     puts "\n----------------------------------------------------------------------------------"
     puts 'Configuration:'
     puts "\t:working directory: #{Rake.original_dir}"
     puts "\t:project: #{project}"
     puts "\t:aws_secrets_file: #{aws_secrets_file}"
-    puts "\t:access_key_id: #{credentials['access_key_id']}"
+    puts "\t:access_key_id: #{credentials[:access_key_id]}"
     puts "----------------------------------------------------------------------------------\n"
   end
 
-  # validate file exists
-  def credentials!
+  def credentials
     unless File.exists?(aws_secrets_file)
       puts "\nWarning: Config file is missing: #{aws_secrets_file}.\nFile contents should look like:\naccess_key_id: XXXX\nsecret_access_key: XXXX\n\n."
     end
+
+    # load from a user directory i.e. ~/.aws/acme.yml
+    credentials = File.exists?(aws_secrets_file) ? YAML::load_file(aws_secrets_file) : {}
 
     access_key_id     = credentials.fetch('access_key_id') { ENV['AWS_ACCESS_KEY_ID'] }
     secret_access_key = credentials.fetch('secret_access_key') { ENV['AWS_SECRET_ACCESS_KEY'] }
@@ -80,13 +79,6 @@ namespace :mm do
       access_key_id: access_key_id
       secret_access_key: secret_access_key
     }
-
-  end
-
-  # load from a user directory i.e. ~/.aws/acme.yml
-  def credentials
-    # load secrets from the user home directory
-    @credentials ||= YAML::load_file(aws_secrets_file)
   end
 
   def aws_secrets_file

--- a/lib/middleman-aws/tasks/middleman-aws.rake
+++ b/lib/middleman-aws/tasks/middleman-aws.rake
@@ -34,10 +34,12 @@ namespace :mm do
       # puts "## Github Pages deploy complete"
     end
 
+    credentials!
+    aws_env = "AWS_ACCESS_KEY=#{credentials['access_key_id']} AWS_SECRET=#{credentials['secret_access_key']}"
     puts '## Syncing to S3...'
-    system "bundle exec middleman s3_sync"
+    system "#{aws_env} bundle exec middleman s3_sync"
     puts '## Invalidating cloudfront...'
-    system "bundle exec middleman invalidate"
+    system "#{aws_env} bundle exec middleman invalidate"
     puts '## Deploy complete.'
   end
 
@@ -49,6 +51,46 @@ namespace :mm do
   desc 'Run the preview server at http://localhost:4567'
   task :preview do
     system 'middleman server'
+  end
+
+  desc 'Show config'
+  task :show_config do |t, args|
+
+    credentials!
+
+    puts "\n----------------------------------------------------------------------------------"
+    puts 'Configuration:'
+    puts "\t:working directory: #{Rake.original_dir}"
+    puts "\t:project: #{project}"
+    puts "\t:aws_secrets_file: #{aws_secrets_file}"
+    puts "\t:access_key_id: #{credentials['access_key_id']}"
+    puts "----------------------------------------------------------------------------------\n"
+  end
+
+  # validate file exists
+  def credentials!
+    unless File.exists?(aws_secrets_file)
+      puts "\nWarning: Config file is missing: #{aws_secrets_file}.\nFile contents should look like:\naccess_key_id: XXXX\nsecret_access_key: XXXX\n\n."
+    end
+
+    access_key_id     = credentials.fetch('access_key_id') { ENV['AWS_ACCESS_KEY_ID'] }
+    secret_access_key = credentials.fetch('secret_access_key') { ENV['AWS_SECRET_ACCESS_KEY'] }
+
+    {
+      access_key_id: access_key_id
+      secret_access_key: secret_access_key
+    }
+
+  end
+
+  # load from a user directory i.e. ~/.aws/acme.yml
+  def credentials
+    # load secrets from the user home directory
+    @credentials ||= YAML::load_file(aws_secrets_file)
+  end
+
+  def aws_secrets_file
+    File.expand_path("~/.aws/#{project}.yml")
   end
 
   def project

--- a/lib/middleman-aws/tasks/middleman-aws.rake
+++ b/lib/middleman-aws/tasks/middleman-aws.rake
@@ -34,12 +34,10 @@ namespace :mm do
       # puts "## Github Pages deploy complete"
     end
 
-    credentials!
-    aws_env = "AWS_ACCESS_KEY=#{credentials['access_key_id']} AWS_SECRET=#{credentials['secret_access_key']}"
     puts '## Syncing to S3...'
-    system "#{aws_env} bundle exec middleman s3_sync"
+    system "bundle exec middleman s3_sync"
     puts '## Invalidating cloudfront...'
-    system "#{aws_env}  bundle exec middleman invalidate"
+    system "bundle exec middleman invalidate"
     puts '## Deploy complete.'
   end
 
@@ -51,42 +49,6 @@ namespace :mm do
   desc 'Run the preview server at http://localhost:4567'
   task :preview do
     system 'middleman server'
-  end
-
-  desc 'Show config'
-  task :show_config do |t, args|
-
-    credentials!
-
-    puts "\n----------------------------------------------------------------------------------"
-    puts 'Configuration:'
-    puts "\t:working directory: #{Rake.original_dir}"
-    puts "\t:project: #{project}"
-    puts "\t:aws_secrets_file: #{aws_secrets_file}"
-    puts "\t:access_key_id: #{credentials['access_key_id']}"
-    puts "----------------------------------------------------------------------------------\n"
-  end
-
-  # validate file exists
-  def credentials!
-    raise "\nFailed to load AWS secrets: #{aws_secrets_file}.\nFile contents should look like:\naccess_key_id: XXXX\nsecret_access_key: XXXX\n\n" unless File.exists?(aws_secrets_file)
-    credentials
-
-    ['access_key_id', 'secret_access_key'].each do |key|
-      value = credentials[key]
-      raise "\nThe #{key} must be specified in the #{aws_secrets_file}.\n\n" if value.nil?
-    end
-  end
-
-  # load from a user directory i.e. ~/.aws/acme.yml
-  def credentials
-    # load secrets from the user home directory
-    @credentials = YAML::load_file(aws_secrets_file) if @credentials.nil?
-    @credentials
-  end
-
-  def aws_secrets_file
-    File.expand_path("~/.aws/#{project}.yml")
   end
 
   def project


### PR DESCRIPTION
Currently it's impossible to use this rake task from EC2 instances, because without credentials files rake tasks explodes with exception. 

It's AWS security best practice _not_ to store credentials in a text file on instance. Instead, IAM roles must be used. 

It also makes no sense to use additional credentials file for this gem, because credentials for S3 and CloudFront are already configured inside middleman-s3_sync and middleman-cloudfront. 

I've already added IAM role supprot to middleman-s3_sync here https://github.com/fredjean/middleman-s3_sync/pull/85
